### PR TITLE
[FEAT] - Reakit menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "@emotion/react": "^11.1.5",
     "@emotion/serialize": "^1.0.2",
     "@emotion/styled": "^11.1.5",
-    "@headlessui/react": "^1.0.0",
     "@liinkiing/react-hooks": "^1.8.1",
     "@styled-system/css": "^5.1.5",
     "@styled-system/should-forward-prop": "^5.1.5",

--- a/src/components/menu/Menu.context.ts
+++ b/src/components/menu/Menu.context.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { MenuStateReturn } from 'reakit'
+import type { MenuStateReturn } from 'reakit/Menu'
 
 export interface Context {
   readonly reakitMenu: MenuStateReturn

--- a/src/components/menu/Menu.context.ts
+++ b/src/components/menu/Menu.context.ts
@@ -1,19 +1,16 @@
 import * as React from 'react'
+import { MenuStateReturn } from 'reakit'
 
-export type Context = {
-  readonly open: boolean
+export interface Context extends MenuStateReturn {
   readonly closeOnSelect: boolean
 }
 
-export const MenuContext = React.createContext<Context>({
-  open: false,
-  closeOnSelect: true,
-})
+export const MenuContext = React.createContext<Context | undefined>(undefined)
 
 export const useMenu = (): Context => {
   const context = React.useContext(MenuContext)
   if (!context) {
-    throw new Error(`You can't use the MenuContext outsides a Menu component.`)
+    throw new Error(`You can't use the ReakitMenuContext outsides a ReakitMenu component.`)
   }
   return context
 }

--- a/src/components/menu/Menu.context.ts
+++ b/src/components/menu/Menu.context.ts
@@ -1,7 +1,9 @@
 import * as React from 'react'
 import { MenuStateReturn } from 'reakit'
 
-export interface Context extends MenuStateReturn {
+export interface Context {
+  readonly reakitMenu: MenuStateReturn
+  readonly hideOnClickOutside: boolean
   readonly closeOnSelect: boolean
 }
 

--- a/src/components/menu/Menu.stories.tsx
+++ b/src/components/menu/Menu.stories.tsx
@@ -85,7 +85,7 @@ WithModalOptions.args = {
         color="white"
         bg="cyan.500"
         disclosure={
-          <Menu.ListItem>
+          <Menu.ListItem closeOnSelect={false}>
             <Icon as={FiUser} />
             <Text>Open profile</Text>
           </Menu.ListItem>

--- a/src/components/menu/Menu.stories.tsx
+++ b/src/components/menu/Menu.stories.tsx
@@ -5,6 +5,7 @@ import { Button } from '../button'
 import Text from '../typography/Text'
 import { Icon } from '../icon'
 import { FiChevronDown, FiChevronUp, FiEdit, FiLogOut, FiPrinter, FiSettings, FiUser } from 'react-icons/fi'
+import { Modal } from '../modal'
 
 const meta: Meta = {
   title: 'Library/Menu',
@@ -32,7 +33,7 @@ export const Default = Template.bind({})
 
 Default.args = {
   menuList: (
-    <Menu.List>
+    <Menu.List ariaLabel="menu">
       <Menu.ListItem>
         <Icon as={FiSettings} />
         <Text>Preferences</Text>
@@ -53,11 +54,49 @@ export const WithDivider = Template.bind({})
 
 WithDivider.args = {
   menuList: (
-    <Menu.List>
+    <Menu.List ariaLabel="menu">
       <Menu.ListItem>
         <Icon as={FiUser} />
         <Text>My profile</Text>
       </Menu.ListItem>
+      <Menu.ListItem disabled>
+        <Icon as={FiEdit} />
+        <Text>Edit (not available yet)</Text>
+      </Menu.ListItem>
+      <Menu.ListItem>
+        <Icon as={FiPrinter} />
+        <Text>Print</Text>
+      </Menu.ListItem>
+      <Menu.Divider />
+      <Menu.ListItem>
+        <Icon as={FiLogOut} />
+        <Text>Logout</Text>
+      </Menu.ListItem>
+    </Menu.List>
+  ),
+}
+
+export const WithModalOptions = Template.bind({})
+
+WithModalOptions.args = {
+  menuList: (
+    <Menu.List ariaLabel="menu">
+      <Modal
+        color="white"
+        bg="cyan.500"
+        disclosure={
+          <Menu.ListItem>
+            <Icon as={FiUser} />
+            <Text>Open profile</Text>
+          </Menu.ListItem>
+        }
+        ariaLabel="profile-modal"
+      >
+        <Modal.Header>User profile</Modal.Header>
+        <Modal.Body>
+          <Text>Hello from your profile</Text>
+        </Modal.Body>
+      </Modal>
       <Menu.ListItem disabled>
         <Icon as={FiEdit} />
         <Text>Edit (not available yet)</Text>
@@ -83,7 +122,7 @@ export const WithOptionGroups: Story<MenuProps> = args => {
       <Menu.Button as={Button} variant="primary">
         Menu
       </Menu.Button>
-      <Menu.List>
+      <Menu.List ariaLabel="menu">
         <Menu.OptionGroup value={sorting} onChange={setSorting} type="radio" title="Sorting">
           <Menu.OptionItem value="asc">
             <Text>Ascending</Text>

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -51,6 +51,7 @@ const Menu: FC<MenuProps> & SubComponents = ({
     closeOnSelect,
     hideOnClickOutside,
   ])
+
   return (
     <MenuContext.Provider value={context}>
       <Box position="relative" display="inline-block">
@@ -59,7 +60,8 @@ const Menu: FC<MenuProps> & SubComponents = ({
           placement={placement}
           render={attrs => (list ? React.cloneElement(list, attrs) : null)}
           animation
-          trigger="click"
+          visible={menu.visible}
+          onClickOutside={menu.hide}
           popperOptions={{
             strategy: 'fixed',
           }}

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -18,6 +18,10 @@ export interface MenuProps
     Partial<Pick<TippyProps, 'placement'>>,
     Pick<MenuInitialState, 'loop'>,
     Pick<ReakitMenuProps, 'hideOnClickOutside'> {
+  /**
+   * When enabled, the menu will auto close itself after you've selected a choice. It can also be enabled on a
+   * per-instance of a `Menu.ListItem`
+   */
   readonly closeOnSelect?: boolean
 }
 
@@ -45,6 +49,7 @@ const Menu: FC<MenuProps> & SubComponents = ({
   const context = useMemo<Context>(() => ({ reakitMenu: menu, closeOnSelect, hideOnClickOutside }), [
     menu,
     closeOnSelect,
+    hideOnClickOutside,
   ])
   return (
     <MenuContext.Provider value={context}>

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -34,7 +34,7 @@ type SubComponents = {
   OptionItem: typeof MenuOptionItem
 }
 
-const TRANSITION_DURATION = 0.2
+export const TRANSITION_DURATION = 0.2
 
 const Menu: FC<MenuProps> & SubComponents = ({
   placement = 'bottom-start',

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -9,7 +9,7 @@ import Box from '../primitives/Box'
 import { FC, ReactElement, useMemo } from 'react'
 import MenuList from './MenuList'
 import { CommonProps } from './common'
-import { MenuInitialState, useMenuState, MenuProps as ReakitMenuProps } from 'reakit'
+import { MenuInitialState, useMenuState, MenuProps as ReakitMenuProps } from 'reakit/Menu'
 import { Context, MenuContext } from './Menu.context'
 import { KleeZIndex, Z_INDICES } from '../../styles/theme'
 

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -9,10 +9,15 @@ import Box from '../primitives/Box'
 import { FC, ReactElement, useMemo } from 'react'
 import MenuList from './MenuList'
 import { CommonProps } from './common'
-import { useMenuState } from 'reakit'
+import { MenuInitialState, useMenuState, MenuProps as ReakitMenuProps } from 'reakit'
 import { Context, MenuContext } from './Menu.context'
+import { KleeZIndex, Z_INDICES } from '../../styles/theme'
 
-export interface MenuProps extends CommonProps, Partial<Pick<TippyProps, 'placement'>> {
+export interface MenuProps
+  extends CommonProps,
+    Partial<Pick<TippyProps, 'placement'>>,
+    Pick<MenuInitialState, 'loop'>,
+    Pick<ReakitMenuProps, 'hideOnClickOutside'> {
   readonly closeOnSelect?: boolean
 }
 
@@ -27,16 +32,25 @@ type SubComponents = {
 
 const TRANSITION_DURATION = 0.2
 
-const Menu: FC<MenuProps> & SubComponents = ({ placement = 'bottom-start', closeOnSelect = true, children }) => {
+const Menu: FC<MenuProps> & SubComponents = ({
+  placement = 'bottom-start',
+  closeOnSelect = true,
+  loop = false,
+  hideOnClickOutside = true,
+  children,
+}) => {
   const button = React.Children.toArray(children).find((c: any) => c.type === MenuButton) as ReactElement
   const list = React.Children.toArray(children).find((c: any) => c.type === MenuList) as ReactElement
-  const menu = useMenuState({ animated: TRANSITION_DURATION * 1000 })
-  const context = useMemo<Context>(() => ({ ...menu, closeOnSelect }), [menu, closeOnSelect])
-  console.log({ context })
+  const menu = useMenuState({ animated: TRANSITION_DURATION * 1000, loop })
+  const context = useMemo<Context>(() => ({ reakitMenu: menu, closeOnSelect, hideOnClickOutside }), [
+    menu,
+    closeOnSelect,
+  ])
   return (
     <MenuContext.Provider value={context}>
       <Box position="relative" display="inline-block">
         <Tippy
+          zIndex={Z_INDICES[KleeZIndex.Dropdown]}
           placement={placement}
           render={attrs => (list ? React.cloneElement(list, attrs) : null)}
           animation

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -61,7 +61,6 @@ const Menu: FC<MenuProps> & SubComponents = ({
           render={attrs => (list ? React.cloneElement(list, attrs) : null)}
           animation
           visible={menu.visible}
-          onClickOutside={menu.hide}
           popperOptions={{
             strategy: 'fixed',
           }}

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -16,8 +16,8 @@ import { KleeZIndex, Z_INDICES } from '../../styles/theme'
 export interface MenuProps
   extends CommonProps,
     Partial<Pick<TippyProps, 'placement'>>,
-    Pick<MenuInitialState, 'loop'>,
-    Pick<ReakitMenuProps, 'hideOnClickOutside'> {
+    Partial<Pick<MenuInitialState, 'loop'>>,
+    Partial<Pick<ReakitMenuProps, 'hideOnClickOutside'>> {
   /**
    * When enabled, the menu will auto close itself after you've selected a choice. It can also be enabled on a
    * per-instance of a `Menu.ListItem`

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -1,26 +1,20 @@
 import * as React from 'react'
-import { Menu as HeadlessMenu } from '@headlessui/react'
 import Tippy, { TippyProps } from '@tippyjs/react/headless'
-import MenuButton, { MENU_BUTTON_TYPE } from './MenuButton'
+import MenuButton from './MenuButton'
 import MenuDivider from './MenuDivider'
 import MenuListItem from './MenuListItem'
 import MenuOptionGroup from './MenuOptionGroup'
 import MenuOptionItem from './MenuOptionItem'
-import { Context, MenuContext } from './Menu.context'
 import Box from '../primitives/Box'
-import { FC, ReactNode } from 'react'
-import MenuList, { MENU_LIST_TYPE } from './MenuList'
+import { FC, ReactElement, useMemo } from 'react'
+import MenuList from './MenuList'
 import { CommonProps } from './common'
+import { useMenuState } from 'reakit'
+import { Context, MenuContext } from './Menu.context'
 
 export interface MenuProps extends CommonProps, Partial<Pick<TippyProps, 'placement'>> {
   readonly closeOnSelect?: boolean
 }
-
-const Provider = ({ context: { open, closeOnSelect }, children }: { context: Context; children: ReactNode }) => (
-  <MenuContext.Provider value={{ open, closeOnSelect }}>
-    {typeof children === 'function' ? children({ open }) : children}
-  </MenuContext.Provider>
-)
 
 type SubComponents = {
   Button: typeof MenuButton
@@ -31,30 +25,30 @@ type SubComponents = {
   OptionItem: typeof MenuOptionItem
 }
 
-const Menu: FC<MenuProps> & SubComponents = ({ placement = 'bottom-end', closeOnSelect = true, children }) => {
-  const button = React.Children.toArray(children).find(c => (c as any).type.name === MENU_BUTTON_TYPE) as any
-  const list = React.Children.toArray(children).find(c => (c as any).type.name === MENU_LIST_TYPE) as any
+const TRANSITION_DURATION = 0.2
 
+const Menu: FC<MenuProps> & SubComponents = ({ placement = 'bottom-start', closeOnSelect = true, children }) => {
+  const button = React.Children.toArray(children).find((c: any) => c.type === MenuButton) as ReactElement
+  const list = React.Children.toArray(children).find((c: any) => c.type === MenuList) as ReactElement
+  const menu = useMenuState({ animated: TRANSITION_DURATION * 1000 })
+  const context = useMemo<Context>(() => ({ ...menu, closeOnSelect }), [menu, closeOnSelect])
+  console.log({ context })
   return (
-    <Box position="relative" display="inline-block">
-      <HeadlessMenu>
-        {({ open }) => (
-          <Provider context={{ open, closeOnSelect }}>
-            <Tippy
-              placement={placement}
-              render={attrs => (list ? React.cloneElement(list, attrs) : null)}
-              animation
-              trigger="click"
-              popperOptions={{
-                strategy: 'fixed',
-              }}
-            >
-              {button}
-            </Tippy>
-          </Provider>
-        )}
-      </HeadlessMenu>
-    </Box>
+    <MenuContext.Provider value={context}>
+      <Box position="relative" display="inline-block">
+        <Tippy
+          placement={placement}
+          render={attrs => (list ? React.cloneElement(list, attrs) : null)}
+          animation
+          trigger="click"
+          popperOptions={{
+            strategy: 'fixed',
+          }}
+        >
+          {button}
+        </Tippy>
+      </Box>
+    </MenuContext.Provider>
   )
 }
 

--- a/src/components/menu/MenuButton.tsx
+++ b/src/components/menu/MenuButton.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { MenuButton as ReakitMenuButton } from 'reakit'
+import { MenuButton as ReakitMenuButton } from 'reakit/Menu'
 import { PolymorphicComponent } from '../primitives/Box'
 import { CommonProps } from './common'
 import { Button } from '../button'

--- a/src/components/menu/MenuButton.tsx
+++ b/src/components/menu/MenuButton.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react'
-import { Menu as HeadlessMenu } from '@headlessui/react'
+import { MenuButton as ReakitMenuButton } from 'reakit'
 import { PolymorphicComponent } from '../primitives/Box'
 import { CommonProps } from './common'
-
-export const MENU_BUTTON_TYPE: 'MenuButton' = 'MenuButton'
+import { Button } from '../button'
+import { useMenu } from './Menu.context'
 
 const MenuButton = React.forwardRef<HTMLButtonElement, any>(({ ...props }, ref) => {
-  return <HeadlessMenu.Button ref={ref} {...props} />
+  const menu = useMenu()
+  return <ReakitMenuButton as={Button} ref={ref} {...menu} {...props} />
 })
 
-;(MenuButton as any).name = MENU_BUTTON_TYPE
 MenuButton.displayName = 'Menu.Button'
 
 export default MenuButton as PolymorphicComponent<CommonProps>

--- a/src/components/menu/MenuButton.tsx
+++ b/src/components/menu/MenuButton.tsx
@@ -6,8 +6,8 @@ import { Button } from '../button'
 import { useMenu } from './Menu.context'
 
 const MenuButton = React.forwardRef<HTMLButtonElement, any>(({ ...props }, ref) => {
-  const menu = useMenu()
-  return <ReakitMenuButton as={Button} ref={ref} {...menu} {...props} />
+  const { reakitMenu } = useMenu()
+  return <ReakitMenuButton as={Button} ref={ref} {...reakitMenu} {...props} />
 })
 
 MenuButton.displayName = 'Menu.Button'

--- a/src/components/menu/MenuList.tsx
+++ b/src/components/menu/MenuList.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import { forwardRef } from 'react'
-import { Menu as HeadlessMenu } from '@headlessui/react'
 import styled from '@emotion/styled'
 import { AnimatePresence, motion } from 'framer-motion'
 import { BoxProps } from '../primitives/Box'
@@ -10,6 +9,7 @@ import { useMenu } from './Menu.context'
 import { LAYOUT_TRANSITION_SPRING } from '../../utils/motion'
 import { KleeFontSize } from '../../styles/theme/typography'
 import { KleeBorder, KleeRadius, KleeShadow, KleeZIndex } from '../../styles/theme'
+import { Menu } from 'reakit'
 
 export interface MenuListProps extends Omit<BoxProps, 'children'>, CommonProps {
   readonly align?: 'left' | 'right'
@@ -25,17 +25,14 @@ const MenuItems = styled(motion(Flex))`
 `
 
 const MenuList = forwardRef<HTMLElement, MenuListProps>(({ children, align = 'right', ...props }, ref) => {
-  const { open, closeOnSelect } = useMenu()
-
+  const menu = useMenu()
   return (
     <AnimatePresence>
-      {open && (
-        <HeadlessMenu.Items
-          static
-          closeOnSelect={closeOnSelect}
+      {menu.visible && (
+        <Menu
           ref={ref}
+          {...menu}
           as={MenuItems}
-          align={align}
           direction="column"
           minWidth="200px"
           bg="white"
@@ -54,13 +51,12 @@ const MenuList = forwardRef<HTMLElement, MenuListProps>(({ children, align = 'ri
           exit={{ opacity: 0, y: -10 }}
         >
           {children}
-        </HeadlessMenu.Items>
+        </Menu>
       )}
     </AnimatePresence>
   )
 })
 
-;(MenuList as any).name = MENU_LIST_TYPE
 MenuList.displayName = 'Menu.List'
 
 export default MenuList

--- a/src/components/menu/MenuList.tsx
+++ b/src/components/menu/MenuList.tsx
@@ -7,10 +7,11 @@ import { BoxProps } from '../primitives/Box'
 import { CommonProps } from './common'
 import Flex from '../layout/Flex'
 import { useMenu } from './Menu.context'
-import { LAYOUT_TRANSITION_SPRING } from '../../utils/motion'
+import { ease } from '../../utils/motion'
 import { KleeFontSize } from '../../styles/theme/typography'
 import { KleeBorder, KleeRadius, KleeShadow, KleeZIndex } from '../../styles/theme'
 import { Menu } from 'reakit/Menu'
+import { TRANSITION_DURATION } from './Menu'
 
 export type MenuListProps = Omit<BoxProps, 'children'> &
   CommonProps &
@@ -44,7 +45,7 @@ const MenuList = forwardRef<HTMLElement, MenuListProps>(({ children, ariaLabel, 
           aria-labelledby={labelledby}
           hideOnClickOutside={hideOnClickOutside}
           {...reakitMenu}
-          style={{ outline: 'none' }}
+          style={{ outline: 'none', transformOrigin: 'top left' }}
           as={MenuItems}
           ref={ref}
           direction="column"
@@ -58,10 +59,10 @@ const MenuList = forwardRef<HTMLElement, MenuListProps>(({ children, ariaLabel, 
           zIndex={KleeZIndex.Dropdown}
           overflow="hidden"
           {...props}
-          initial={{ opacity: 0, y: -10 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={LAYOUT_TRANSITION_SPRING}
-          exit={{ opacity: 0, y: -10 }}
+          initial={{ opacity: 0, y: -10, scale: 0.9 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          transition={{ duration: TRANSITION_DURATION, ease }}
+          exit={{ opacity: 0, y: -10, scale: 0.9 }}
         >
           {children}
         </Menu>

--- a/src/components/menu/MenuList.tsx
+++ b/src/components/menu/MenuList.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { FC } from 'react'
 import { forwardRef } from 'react'
 import styled from '@emotion/styled'
 import { AnimatePresence, motion } from 'framer-motion'
@@ -11,11 +12,18 @@ import { KleeFontSize } from '../../styles/theme/typography'
 import { KleeBorder, KleeRadius, KleeShadow, KleeZIndex } from '../../styles/theme'
 import { Menu } from 'reakit'
 
-export interface MenuListProps extends Omit<BoxProps, 'children'>, CommonProps {
-  readonly align?: 'left' | 'right'
-}
-
-export const MENU_LIST_TYPE: 'MenuList' = 'MenuList'
+export type MenuListProps = Omit<BoxProps, 'children'> &
+  CommonProps &
+  (
+    | {
+        ariaLabel: string
+        ariaLabelledby?: never
+      }
+    | {
+        ariaLabel?: never
+        ariaLabelledby: string
+      }
+  )
 
 const MenuItems = styled(motion(Flex))`
   &:active,
@@ -24,20 +32,25 @@ const MenuItems = styled(motion(Flex))`
   }
 `
 
-const MenuList = forwardRef<HTMLElement, MenuListProps>(({ children, align = 'right', ...props }, ref) => {
-  const menu = useMenu()
+const MenuList = forwardRef<HTMLElement, MenuListProps>(({ children, ariaLabel, ariaLabelledby, ...props }, ref) => {
+  const { reakitMenu, hideOnClickOutside } = useMenu()
+  const label = ariaLabel ?? props['aria-label'] ?? undefined
+  const labelledby = ariaLabelledby ?? props['aria-labelledby'] ?? undefined
   return (
     <AnimatePresence>
-      {menu.visible && (
+      {reakitMenu.visible && (
         <Menu
-          ref={ref}
-          {...menu}
+          aria-label={label}
+          aria-labelledby={labelledby}
+          hideOnClickOutside={hideOnClickOutside}
+          {...reakitMenu}
+          style={{ outline: 'none' }}
           as={MenuItems}
+          ref={ref}
           direction="column"
           minWidth="200px"
           bg="white"
           boxShadow={KleeShadow.Lg}
-          mt={2}
           border={KleeBorder.Xs}
           fontSize={KleeFontSize.Sm}
           borderColor="cool-gray.200"
@@ -55,7 +68,7 @@ const MenuList = forwardRef<HTMLElement, MenuListProps>(({ children, align = 'ri
       )}
     </AnimatePresence>
   )
-})
+}) as FC<MenuListProps>
 
 MenuList.displayName = 'Menu.List'
 

--- a/src/components/menu/MenuList.tsx
+++ b/src/components/menu/MenuList.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { FC } from 'react'
 import { forwardRef } from 'react'
 import styled from '@emotion/styled'
-import { AnimatePresence, motion } from 'framer-motion'
+import { motion } from 'framer-motion'
 import { BoxProps } from '../primitives/Box'
 import { CommonProps } from './common'
 import Flex from '../layout/Flex'
@@ -38,36 +38,35 @@ const MenuList = forwardRef<HTMLElement, MenuListProps>(({ children, ariaLabel, 
   const label = ariaLabel ?? props['aria-label'] ?? undefined
   const labelledby = ariaLabelledby ?? props['aria-labelledby'] ?? undefined
   return (
-    <AnimatePresence>
-      {reakitMenu.visible && (
-        <Menu
-          aria-label={label}
-          aria-labelledby={labelledby}
-          hideOnClickOutside={hideOnClickOutside}
-          {...reakitMenu}
-          style={{ outline: 'none', transformOrigin: 'top left' }}
-          as={MenuItems}
-          ref={ref}
-          direction="column"
-          minWidth="200px"
-          bg="white"
-          boxShadow={KleeShadow.Lg}
-          border={KleeBorder.Xs}
-          fontSize={KleeFontSize.Sm}
-          borderColor="cool-gray.200"
-          borderRadius={KleeRadius.Lg}
-          zIndex={KleeZIndex.Dropdown}
-          overflow="hidden"
-          {...props}
-          initial={{ opacity: 0, y: -10, scale: 0.9 }}
-          animate={{ opacity: 1, y: 0, scale: 1 }}
-          transition={{ duration: TRANSITION_DURATION, ease }}
-          exit={{ opacity: 0, y: -10, scale: 0.9 }}
-        >
-          {children}
-        </Menu>
-      )}
-    </AnimatePresence>
+    <Menu
+      variants={{
+        hidden: { opacity: 0, y: -10, scale: 0.9 },
+        visible: { opacity: 1, y: 0, scale: 1 },
+      }}
+      aria-label={label}
+      aria-labelledby={labelledby}
+      hideOnClickOutside={hideOnClickOutside}
+      {...reakitMenu}
+      style={{ outline: 'none', transformOrigin: 'top left' }}
+      as={MenuItems}
+      ref={ref}
+      direction="column"
+      minWidth="200px"
+      bg="white"
+      boxShadow={KleeShadow.Lg}
+      border={KleeBorder.Xs}
+      fontSize={KleeFontSize.Sm}
+      borderColor="cool-gray.200"
+      borderRadius={KleeRadius.Lg}
+      zIndex={KleeZIndex.Dropdown}
+      overflow="hidden"
+      {...props}
+      initial="hidden"
+      animate={reakitMenu.visible ? 'visible' : 'hidden'}
+      transition={{ duration: TRANSITION_DURATION, ease }}
+    >
+      {children}
+    </Menu>
   )
 }) as FC<MenuListProps>
 

--- a/src/components/menu/MenuList.tsx
+++ b/src/components/menu/MenuList.tsx
@@ -10,7 +10,7 @@ import { useMenu } from './Menu.context'
 import { LAYOUT_TRANSITION_SPRING } from '../../utils/motion'
 import { KleeFontSize } from '../../styles/theme/typography'
 import { KleeBorder, KleeRadius, KleeShadow, KleeZIndex } from '../../styles/theme'
-import { Menu } from 'reakit'
+import { Menu } from 'reakit/Menu'
 
 export type MenuListProps = Omit<BoxProps, 'children'> &
   CommonProps &

--- a/src/components/menu/MenuListItem.tsx
+++ b/src/components/menu/MenuListItem.tsx
@@ -1,6 +1,6 @@
 /** @jsxRuntime classic */
 /** @jsx jsx */
-import { FC, ReactNode } from 'react'
+import { FC, forwardRef, ReactNode } from 'react'
 import { jsx } from '@emotion/react'
 import styled from '@emotion/styled'
 import css from '@styled-system/css'
@@ -9,6 +9,7 @@ import { BoxProps } from '../primitives/Box'
 import { useMenu } from './Menu.context'
 import Text from '../typography/Text'
 import { MenuItem } from 'reakit'
+import { KleeLineHeight } from '../../styles/theme/typography'
 
 export interface MenuListItemProps extends BoxProps {
   readonly disabled?: boolean
@@ -18,12 +19,11 @@ export interface MenuListItemProps extends BoxProps {
 const MenuListItemInner = styled(Flex)`
   pointer-events: all;
   &[disabled] {
-    pointer-events: none;
+    cursor: not-allowed;
   }
   &:hover {
     cursor: pointer;
     &[disabled] {
-      pointer-events: none;
       cursor: not-allowed;
     }
   }
@@ -33,36 +33,38 @@ const MenuListItemInner = styled(Flex)`
   }
 `
 
-const MenuListItem: FC<MenuListItemProps> = ({ disabled, children, ...props }) => {
-  const menu = useMenu()
-  return (
-    <MenuItem
-      as={MenuListItemInner}
-      {...props}
-      {...menu}
-      px={3}
-      py={2}
-      _focus={{ bg: 'cool-gray.100' }}
-      _disabled={{ color: props.color ?? 'cool-gray.500' }}
-      align="center"
-      lineHeight="base"
-      borderBottom="normal"
-      borderColor="cool-gray.200"
-      sx={css({
-        '&:last-of-type': {
-          borderBottom: 0,
-        },
-        '& svg + *': {
-          ml: 2,
-        },
-      })}
-      {...props}
-    >
-      {typeof children === 'string' ? <Text>{children}</Text> : children}
-    </MenuItem>
-  )
-}
-
+const MenuListItem: FC<MenuListItemProps> = forwardRef<HTMLElement, MenuListItemProps>(
+  ({ disabled, children, ...props }, ref) => {
+    const { reakitMenu } = useMenu()
+    return (
+      <MenuItem
+        as={MenuListItemInner}
+        disabled={disabled}
+        ref={ref}
+        {...props}
+        {...reakitMenu}
+        px={3}
+        py={2}
+        _focus={{ bg: 'cool-gray.100' }}
+        _disabled={{ color: props.color ?? 'cool-gray.500' }}
+        align="center"
+        lineHeight={KleeLineHeight.Normal}
+        borderColor="cool-gray.200"
+        css={css({
+          '&:last-of-type': {
+            borderBottom: 0,
+          },
+          '& svg + *': {
+            ml: 2,
+          },
+        })}
+        {...props}
+      >
+        {typeof children === 'string' ? <Text>{children}</Text> : children}
+      </MenuItem>
+    )
+  },
+)
 MenuListItem.displayName = 'Menu.ListItem'
 
 export default MenuListItem

--- a/src/components/menu/MenuListItem.tsx
+++ b/src/components/menu/MenuListItem.tsx
@@ -8,7 +8,7 @@ import Flex from '../layout/Flex'
 import { BoxProps } from '../primitives/Box'
 import { useMenu } from './Menu.context'
 import Text from '../typography/Text'
-import { MenuItem } from 'reakit'
+import { MenuItem } from 'reakit/Menu'
 import { KleeLineHeight } from '../../styles/theme/typography'
 import { MenuProps } from './Menu'
 

--- a/src/components/menu/MenuListItem.tsx
+++ b/src/components/menu/MenuListItem.tsx
@@ -2,13 +2,13 @@
 /** @jsx jsx */
 import { FC, ReactNode } from 'react'
 import { jsx } from '@emotion/react'
-import { Menu as HeadlessMenu } from '@headlessui/react'
 import styled from '@emotion/styled'
 import css from '@styled-system/css'
 import Flex from '../layout/Flex'
 import { BoxProps } from '../primitives/Box'
 import { useMenu } from './Menu.context'
 import Text from '../typography/Text'
+import { MenuItem } from 'reakit'
 
 export interface MenuListItemProps extends BoxProps {
   readonly disabled?: boolean
@@ -34,37 +34,32 @@ const MenuListItemInner = styled(Flex)`
 `
 
 const MenuListItem: FC<MenuListItemProps> = ({ disabled, children, ...props }) => {
-  const { closeOnSelect } = useMenu()
+  const menu = useMenu()
   return (
-    // @ts-ignore
-    <HeadlessMenu.Item closeOnSelect={closeOnSelect} disabled={disabled}>
-      {({ active }) => (
-        <MenuListItemInner
-          disabled={disabled}
-          px={3}
-          py={2}
-          bg={active ? 'cool-gray.100' : 'transparent'}
-          align="center"
-          lineHeight="base"
-          borderBottom="normal"
-          borderColor="cool-gray.200"
-          css={css({
-            '&:last-of-type': {
-              borderBottom: 0,
-            },
-            '& svg + *': {
-              ml: 2,
-            },
-            '&[disabled]': {
-              color: props.color ?? 'cool-gray.500',
-            },
-          })}
-          {...props}
-        >
-          {typeof children === 'string' ? <Text>{children}</Text> : children}
-        </MenuListItemInner>
-      )}
-    </HeadlessMenu.Item>
+    <MenuItem
+      as={MenuListItemInner}
+      {...props}
+      {...menu}
+      px={3}
+      py={2}
+      _focus={{ bg: 'cool-gray.100' }}
+      _disabled={{ color: props.color ?? 'cool-gray.500' }}
+      align="center"
+      lineHeight="base"
+      borderBottom="normal"
+      borderColor="cool-gray.200"
+      sx={css({
+        '&:last-of-type': {
+          borderBottom: 0,
+        },
+        '& svg + *': {
+          ml: 2,
+        },
+      })}
+      {...props}
+    >
+      {typeof children === 'string' ? <Text>{children}</Text> : children}
+    </MenuItem>
   )
 }
 

--- a/src/components/modal/ModalHeader.tsx
+++ b/src/components/modal/ModalHeader.tsx
@@ -11,6 +11,7 @@ import { KleeFontSize } from '../../styles/theme/typography'
 import { FlexProps } from '../layout/Flex'
 import { IconButton } from '../button/IconButton'
 import { Icon } from '../icon'
+import { Heading } from '../typography'
 
 const ModalHeader: FC<FlexProps> = ({ children, ...rest }) => {
   const { hide, hideCloseButton } = useModal()
@@ -25,7 +26,7 @@ const ModalHeader: FC<FlexProps> = ({ children, ...rest }) => {
         })}
         flex={1}
       >
-        {children}
+        {typeof children === 'string' ? <Heading as="h2">{children}</Heading> : children}
       </Box>
       {!hideCloseButton && <IconButton variant="transparent" icon={<Icon as={FiX} />} onClick={hide} />}
     </Flex>

--- a/src/components/primitives/Box.tsx
+++ b/src/components/primitives/Box.tsx
@@ -324,7 +324,7 @@ export const Box = styled('div', { shouldForwardProp })<BoxProps>(
       '&:active': _active ?? {},
       '&[aria-selected="true"]': _selected ?? {},
       '&:focus': disableFocusStyles ? { ..._focus, outline: 'none', boxShadow: 'none' } : _focus ?? {},
-      '&:disabled': _disabled ?? {},
+      '&:disabled,&[disabled],&[aria-disabled="true"]': _disabled ?? {},
     }),
   ({ _variants }) => (Array.isArray(_variants) ? _variants.map(v => v) : _variants ?? {}),
   compose(

--- a/src/components/tooltip/Tooltip.tsx
+++ b/src/components/tooltip/Tooltip.tsx
@@ -12,7 +12,7 @@ import Box, { BoxProps } from '../primitives/Box'
 import { FC, ReactNode } from 'react'
 import { LAYOUT_TRANSITION_SPRING } from '../../utils/motion'
 import { Text } from '../typography'
-import { KleeRadius, KleeShadow } from '../../styles/theme'
+import { KleeRadius, KleeShadow, KleeZIndex, Z_INDICES } from '../../styles/theme'
 import { KleeFontSize } from '../../styles/theme/typography'
 import { transparentize } from 'polished'
 import { themeGet } from '@styled-system/theme-get'
@@ -110,6 +110,7 @@ export const Tooltip: FC<TooltipProps> = ({
   const computedBg = bg ?? backgroundColor ?? DEFAULT_BG
   return (
     <Tippy
+      zIndex={Z_INDICES[KleeZIndex.Tooltip]}
       disabled={isDisabled}
       placement={placement}
       interactive={keepOnHover}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2143,11 +2143,6 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
-"@headlessui/react@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.0.0.tgz#661b50ebfd25041abb45d8eedd85e7559056bcaf"
-  integrity sha512-mjqRJrgkbcHQBfAHnqH0yRxO/y/22jYrdltpE7WkurafREKZ+pj5bPBwYHMt935Sdz/n16yRcVmsSCqDFHee9A==
-
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"


### PR DESCRIPTION
We get rid of **@headlessui/react** because it was only used for the `Menu` component and was adding an extra deps when **reakit** can also handle Menus. It also fix a bug when wanting to use Modals inside a ListItem, when using with **@headlessui/react** it was conflicting with the ARIA stuff and the modal was hiding herself 😥

Also I should loose some weights, sorry no **THICCCCCNEEEEEEESSSS** planned for today