### PR TITLE
[FEAT] - Transforms

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -37,6 +37,17 @@ const EXLUDED_DOCGEN_PROPS = [
   'grow',
   'shrink',
   'spacing',
+  'transform',
+  'transformOrigin',
+  'enableGpuAcceleration',
+  'scale',
+  'scaleX',
+  'scaleY',
+  'rotate',
+  'translateX',
+  'translateY',
+  'skewY',
+  'skewX',
 ]
 
 const ALLOWED_DOCGEN_NODE_MODULES = ['tippy.js']

--- a/src/@types/csstype/index.d.ts
+++ b/src/@types/csstype/index.d.ts
@@ -3,5 +3,13 @@ import 'csstype'
 declare module 'csstype' {
   export interface Properties {
     '--klee-focus-border-color'?: any
+    '--klee-transform'?: any
+    '--klee-translate-x'?: any
+    '--klee-translate-y'?: any
+    '--klee-rotate'?: any
+    '--klee-scale-x'?: any
+    '--klee-scale-y'?: any
+    '--klee-skew-x'?: any
+    '--klee-skew-y'?: any
   }
 }

--- a/src/components/primitives/Box.tsx
+++ b/src/components/primitives/Box.tsx
@@ -51,8 +51,8 @@ import {
   KleeLetterSpacing,
   KleeLineHeight,
 } from '../../styles/theme/typography'
-import { CssVars } from '../../utils/css-vars'
-import { bgClipTransform, bgGradientTransform } from '../../utils/styled-system/transforms'
+import { CssVars, transformCssWithVariables, transformGpuCssWithVariables } from '../../utils/css-vars'
+import { bgClipTransform, bgGradientTransform, translateTransform } from '../../utils/styled-system/transforms'
 
 type BoxHTMLProps = RefAttributes<any> & HTMLAttributes<any>
 
@@ -89,6 +89,17 @@ type AppCustomStyledProps = {
   bgClip?: 'text' | (string & {})
   backgroundClip?: 'text' | (string & {})
   focusBorderColor?: AppBorderProps['borderColor']
+  scale?: ResponsiveValue<number>
+  scaleX?: ResponsiveValue<number>
+  scaleY?: ResponsiveValue<number>
+  rotate?: ResponsiveValue<string>
+  translateX?: ResponsiveValue<string | number>
+  translateY?: ResponsiveValue<string | number>
+  skewY?: ResponsiveValue<string | number>
+  skewX?: ResponsiveValue<string | number>
+  transform?: boolean
+  transformOrigin?: ResponsiveValue<CSS.Property.TransformOrigin>
+  enableGpuAcceleration?: boolean
 }
 
 type AppShadowProps = {
@@ -320,14 +331,26 @@ export type PolymorphicComponentProps<E extends ElementType, P> = P & Polymorphi
 
 const defaultElement = 'div'
 
-export const Box = styled('div', { shouldForwardProp })<BoxProps>(
+const ALLOWED_PROPS = ['rotate', 'transform', 'scale']
+
+export const Box = styled('div', {
+  shouldForwardProp: propName => {
+    if (ALLOWED_PROPS.includes(propName.toString())) return false
+    return shouldForwardProp(propName.toString())
+  },
+})<BoxProps>(
   props => ({
     textTransform: props.uppercase ? 'uppercase' : undefined,
     ...bgClipTransform(props.bgClip ?? props.backgroundClip),
   }),
-  ({ sx, _hover, _active, _focus, _disabled, _selected, disableFocusStyles }) =>
+  ({ sx, _hover, _active, _focus, _disabled, _selected, disableFocusStyles, transform, enableGpuAcceleration }) =>
     css({
       ...(sx ?? {}),
+      ...(transform
+        ? {
+            transform: enableGpuAcceleration ? transformGpuCssWithVariables : transformCssWithVariables,
+          }
+        : {}),
       '&:hover': _hover ?? {},
       '&:active': _active ?? {},
       '&[aria-selected="true"]': _selected ?? {},
@@ -349,6 +372,35 @@ export const Box = styled('div', { shouldForwardProp })<BoxProps>(
         properties: ['gap'],
         scale: 'sizes',
       },
+      scale: {
+        properties: [CssVars.ScaleX, CssVars.ScaleY],
+      },
+      scaleX: {
+        properties: [CssVars.ScaleX],
+      },
+      scaleY: {
+        properties: [CssVars.ScaleY],
+      },
+      rotate: {
+        properties: [CssVars.Rotate],
+      },
+      translateX: {
+        properties: [CssVars.TranslateX],
+        scale: 'sizes',
+        transform: translateTransform,
+      },
+      translateY: {
+        properties: [CssVars.TranslateY],
+        scale: 'sizes',
+        transform: translateTransform,
+      },
+      skewY: {
+        properties: [CssVars.SkewY],
+      },
+      skewX: {
+        properties: [CssVars.SkewX],
+      },
+      transformOrigin: true,
       focusBorderColor: {
         property: CssVars.FocusBorderColor,
         scale: 'colors',

--- a/src/utils/css-vars.ts
+++ b/src/utils/css-vars.ts
@@ -2,10 +2,51 @@ import { css } from '@emotion/react'
 
 export enum CssVars {
   FocusBorderColor = '--klee-focus-border-color',
+  Transform = '--klee-transform',
+  TranslateX = '--klee-translate-x',
+  TranslateY = '--klee-translate-y',
+  Rotate = '--klee-rotate',
+  ScaleX = '--klee-scale-x',
+  ScaleY = '--klee-scale-y',
+  SkewX = '--klee-skew-x',
+  SkewY = '--klee-skew-y',
 }
+
+export const cssVar = (value: CssVars, fallback?: any) => {
+  return `var(${value}${fallback ? `, ${fallback}` : ''})`
+}
+
+const transformValues = [
+  `translateX(${cssVar(CssVars.TranslateX)})`,
+  `translateY(${cssVar(CssVars.TranslateY)})`,
+  `rotate(${cssVar(CssVars.Rotate)})`,
+  `scaleX(${cssVar(CssVars.ScaleX)})`,
+  `scaleY(${cssVar(CssVars.ScaleY)})`,
+  `skewX(${cssVar(CssVars.SkewX)})`,
+  `skewY(${cssVar(CssVars.SkewY)})`,
+]
+const transformGpuValues = [
+  `translate3d(${cssVar(CssVars.TranslateX)}, ${cssVar(CssVars.TranslateX)}, 0)`,
+  `rotate(${cssVar(CssVars.Rotate)})`,
+  `scaleX(${cssVar(CssVars.ScaleX)})`,
+  `scaleY(${cssVar(CssVars.ScaleY)})`,
+  `skewX(${cssVar(CssVars.SkewX)})`,
+  `skewY(${cssVar(CssVars.SkewY)})`,
+]
+
+export const transformCssWithVariables = transformValues.join(' ')
+export const transformGpuCssWithVariables = transformGpuValues.join(' ')
 
 export const initializeCssVars = css({
   ':root': {
     [CssVars.FocusBorderColor]: 'rgb(66 153 225 / 60%)',
+    [CssVars.TranslateX]: '0',
+    [CssVars.TranslateY]: '0',
+    [CssVars.Rotate]: '0',
+    [CssVars.ScaleX]: '1',
+    [CssVars.ScaleY]: '1',
+    [CssVars.SkewX]: '0',
+    [CssVars.SkewY]: '0',
+    [CssVars.Transform]: transformValues.join(' '),
   },
 })

--- a/src/utils/styled-system/transforms.ts
+++ b/src/utils/styled-system/transforms.ts
@@ -15,6 +15,29 @@ export const bgClipTransform = (value: string | null | undefined) => {
   return value === 'text' ? { color: 'transparent', backgroundClip: 'text' } : { backgroundClip: value }
 }
 
+export const translateTransform = (value: string | number | null | undefined, scale?: Scale) => {
+  if (!value) return 0
+  if (!scale) {
+    return value
+  }
+  if (typeof value === 'string' && value in scale) {
+    return scale[value as any]
+  }
+  if (typeof value === 'string') {
+    return value
+  }
+  const index = Math.abs(value)
+  const computedValue = scale[index]
+  if (!computedValue) {
+    return `${value}px`
+  }
+  if (value < 0) {
+    return typeof computedValue === 'string' ? `-${computedValue}` : -computedValue
+  }
+
+  return computedValue ?? value
+}
+
 export const bgGradientTransform = (value: string | null | undefined, _scale?: Scale) => {
   if (value == null || globalSet.has(value)) return value
   const regex = /(?<type>^[a-z-A-Z]+)\((?<values>(.*))\)/g


### PR DESCRIPTION
Added a way to handle transforms like in **TailwindCSS** by providing new props like `transform`, `rotate`, `enableGpuAcceleration` etc... They all are sensitive to responsive values 🥵. They are defined in the `Box`, so all the other components herits from it

## New props for Box

```typescript
type Props = {
  scale?: ResponsiveValue<number>
  scaleX?: ResponsiveValue<number>
  scaleY?: ResponsiveValue<number>
  rotate?: ResponsiveValue<string>
  translateX?: ResponsiveValue<string | number>
  translateY?: ResponsiveValue<string | number>
  skewY?: ResponsiveValue<string | number>
  skewX?: ResponsiveValue<string | number>
  transform?: boolean
  transformOrigin?: ResponsiveValue<CSS.Property.TransformOrigin>
  enableGpuAcceleration?: boolean
}
```

## Example

```tsx
<HStack spacing={4} transform translateY={8} rotate={['10deg', '45deg']} skewX="2deg">{children}</HStack>
```